### PR TITLE
Small fix for Google OpenID

### DIFF
--- a/HOAuthAction.php
+++ b/HOAuthAction.php
@@ -203,6 +203,9 @@ class HOAuthAction extends CAction
       {
         // Display the recived error
         switch( $e->getCode() ){ 
+
+		$error = "";
+
         case 0 : $error = "Unspecified error."; break;
         case 1 : $error = "Hybriauth configuration error."; break;
         case 2 : $error = "Provider not properly configured."; break;


### PR DESCRIPTION
Empty $error causes issue when logging in with Google OpenID.
