### PR TITLE
Wrong call to hoauthAfterLogin while checking for hoauthProcessUser meth...

### DIFF
--- a/HOAuthAction.php
+++ b/HOAuthAction.php
@@ -219,7 +219,7 @@ class HOAuthAction extends CAction
 
 					if($this->alwaysCheckPass || $user->isNewRecord)
 						if(method_exists($this->controller, 'hoauthProcessUser'))
-							$user = $this->controller->hoauthAfterLogin($user, $newUser);
+							$user = $this->controller->hoauthProcessUser($user, $newUser);
 						else
 							$user = $this->processUser($user, $userProfile);
 				}


### PR DESCRIPTION
...od

I didn't see hoauthProcessUser callback documented anywhere, but I think there was an error HOAuthAction.php, maybe due to a copy&paste.
After checking existence of hoauthProcessUser, I'd expect to call that method, not hoauthAfterLogin.
By the way, hoauthProcessUser should be documented because it's a powerful callback for those who don't use yii-user and don't want the default implementation of processUser.
