### PR TITLE
Fixed and improved UserOAuth getConfigPath

### DIFF
--- a/models/UserOAuth.php
+++ b/models/UserOAuth.php
@@ -117,8 +117,12 @@ class UserOAuth extends CActiveRecord
 		if(empty($config))
 		{
 			$yiipath = Yii::getPathOfAlias('application.config.hoauth');
+			$config = $yiipath . '.php';
 		}
-		$config = $yiipath . '.php';
+		else if(strpos($config, DIRECTORY_SEPARATOR)===false)
+		{
+			$config = Yii::getPathOfAlias($config).'.php';
+		}
 
 		return $config;
 	}


### PR DESCRIPTION
Fixed bug that occurs if a custom hoauth configuration file is provided.

Improvement
Now a custom configuration file can be provided in form of alias
